### PR TITLE
Fix garbled characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,9 +92,9 @@ module.exports = function(opt) {
       return callback(null, file);
     });
 
-    var hamlData = '';
+    var hamlData = new Buffer(0);
     cp.stdout.on('data', function(data) {
-      hamlData += data.toString();
+      hamlData = Buffer.concat([hamlData, data]);
     });
 
     var errors = '';


### PR DESCRIPTION
This is a fix for a problem that garbled characters may appear at `hamlData += data.toString()` since `data` could be ended (or started) with an incomplete multi-byte character.

Sorry for no test code at this time.