### PR TITLE
Add file path to errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ module.exports = function(opt) {
           message = noHamlError;
         }
       }
-      self.emit('error', new PluginError(PLUGIN_NAME, message));
+      self.emit('error', new PluginError(PLUGIN_NAME, file.path + '\n' + message));
       return callback(null, file);
     });
 
@@ -120,7 +120,7 @@ module.exports = function(opt) {
 
     cp.on('close', function(code) {
       if (errors) {
-        self.emit('error', new PluginError(PLUGIN_NAME, errors));
+        self.emit('error', new PluginError(PLUGIN_NAME, file.path + '\n' + errors));
         return callback(null, null);
       }
 


### PR DESCRIPTION
Closes feature request [#2](https://github.com/cheshire137/gulp-ruby-haml/issues/2)
* Adds file path to errors

Previous behavior:
```shell
Error in plugin 'gulp-ruby-haml'
/.rvm/gems/ruby-2.3.3/gems/haml-4.0.7/lib/haml/engine.rb:131:in `rescue in render': 
(haml):7: syntax error, expected ')' (Haml::SyntaxError)
```

New behavior:
```shell
Error in plugin 'gulp-ruby-haml'
/Users/path/to/detail.tag.haml
/.rvm/gems/ruby-2.3.3/gems/haml-4.0.7/lib/haml/engine.rb:131:in `rescue in render': 
(haml):7: syntax error, expected ')' (Haml::SyntaxError)
```
